### PR TITLE
ci: Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,19 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --merge --auto "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ terraform.tfstate.*
 
 # Vault tokens
 .vault-token
+autobacklog.yaml


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically enables auto-merge on Dependabot PRs
- Once CI passes, Dependabot PRs will merge without manual intervention
- Also adds `autobacklog.yaml` to `.gitignore`

## Test plan
- [ ] Verify workflow triggers on next Dependabot PR
- [ ] Confirm auto-merge activates after CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)