### PR TITLE
fix: Add missing revisionsClient.Close() in GCP provider init

### DIFF
--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -154,6 +154,7 @@ func New(ctx context.Context, config *manifest.ProviderConfig, m *manifest.Manif
 	if err != nil {
 		buildClient.Close()
 		runClient.Close()
+		revisionsClient.Close()
 		storageClient.Close()
 		return nil, fmt.Errorf("failed to create Logging client: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Fixes #32
- Added missing `revisionsClient.Close()` call in the error path when `logadmin.NewClient` fails during GCP provider initialization
- Prevents resource/connection leak on init failure

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/providers/gcp/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)