### PR TITLE
refactor: Use logging package consistently for all CLI output

### DIFF
--- a/cmd/cloud-deploy/main.go
+++ b/cmd/cloud-deploy/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 
 	"github.com/jvreagan/cloud-deploy/pkg/logging"
@@ -37,7 +36,7 @@ func main() {
 	// Load and parse manifest
 	m, err := manifest.Load(*manifestFile)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading manifest: %v\n", err)
+		logging.Errorf("Error loading manifest: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -46,7 +45,7 @@ func main() {
 	// Create provider
 	p, err := provider.Factory(ctx, m)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating provider: %v\n", err)
+		logging.Errorf("Error creating provider: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -55,7 +54,7 @@ func main() {
 	case "deploy":
 		result, err := p.Deploy(ctx, m)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Deployment failed: %v\n", err)
+			logging.Errorf("Deployment failed: %v\n", err)
 			os.Exit(1)
 		}
 		logging.Info("✓ Deployment successful!")
@@ -67,7 +66,7 @@ func main() {
 	case "stop":
 		logging.Info("Stopping deployment...")
 		if err := p.Stop(ctx, m); err != nil {
-			fmt.Fprintf(os.Stderr, "Stop failed: %v\n", err)
+			logging.Errorf("Stop failed: %v\n", err)
 			os.Exit(1)
 		}
 		logging.Info("✓ Deployment stopped successfully")
@@ -75,7 +74,7 @@ func main() {
 	case "destroy":
 		logging.Info("Destroying deployment...")
 		if err := p.Destroy(ctx, m); err != nil {
-			fmt.Fprintf(os.Stderr, "Destroy failed: %v\n", err)
+			logging.Errorf("Destroy failed: %v\n", err)
 			os.Exit(1)
 		}
 		logging.Info("✓ Deployment destroyed successfully")
@@ -83,7 +82,7 @@ func main() {
 	case "status":
 		status, err := p.Status(ctx, m)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to get status: %v\n", err)
+			logging.Errorf("Failed to get status: %v\n", err)
 			os.Exit(1)
 		}
 		logging.Info("Deployment Status:")
@@ -98,7 +97,7 @@ func main() {
 		logging.Info("Rolling back deployment...")
 		result, err := p.Rollback(ctx, m)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Rollback failed: %v\n", err)
+			logging.Errorf("Rollback failed: %v\n", err)
 			os.Exit(1)
 		}
 		logging.Info("✓ Rollback successful!")
@@ -109,8 +108,8 @@ func main() {
 		logging.Infof("  Message: %s", result.Message)
 
 	default:
-		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", *command)
-		fmt.Fprintf(os.Stderr, "Valid commands: deploy, stop, destroy, status, rollback\n")
+		logging.Errorf("Unknown command: %s\n", *command)
+		logging.Error("Valid commands: deploy, stop, destroy, status, rollback")
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes #35
- Replaces all `fmt.Fprintf(os.Stderr, ...)` calls with `logging.Errorf()` / `logging.Error()`
- Removes unused `fmt` import
- All output now goes through the structured logging package consistently

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)