### PR TITLE
feat: Add health check config support to GCP and Azure providers

### DIFF
--- a/pkg/providers/azure/azure.go
+++ b/pkg/providers/azure/azure.go
@@ -554,32 +554,48 @@ func (p *Provider) deployContainerGroup(ctx context.Context, m *manifest.Manifes
 		return '-'
 	}, dnsLabel)
 
+	containerProps := &armcontainerinstance.ContainerProperties{
+		Image: to.Ptr(image),
+		Resources: &armcontainerinstance.ResourceRequirements{
+			Requests: &armcontainerinstance.ResourceRequests{
+				CPU:        to.Ptr(cpu),
+				MemoryInGB: to.Ptr(memoryGB),
+			},
+		},
+		Ports: []*armcontainerinstance.ContainerPort{
+			{
+				Port:     to.Ptr[int32](80),
+				Protocol: to.Ptr(armcontainerinstance.ContainerNetworkProtocolTCP),
+			},
+			{
+				Port:     to.Ptr[int32](443),
+				Protocol: to.Ptr(armcontainerinstance.ContainerNetworkProtocolTCP),
+			},
+		},
+		EnvironmentVariables: envVars,
+	}
+
+	// Apply health check configuration as liveness probe
+	if m.HealthCheck.Path != "" {
+		containerProps.LivenessProbe = &armcontainerinstance.ContainerProbe{
+			HTTPGet: &armcontainerinstance.ContainerHTTPGet{
+				Path: to.Ptr(m.HealthCheck.Path),
+				Port: to.Ptr[int32](80),
+			},
+			PeriodSeconds:      to.Ptr[int32](10),
+			FailureThreshold:   to.Ptr[int32](3),
+			InitialDelaySeconds: to.Ptr[int32](5),
+		}
+		logging.Infof("Configured liveness probe with path: %s", m.HealthCheck.Path)
+	}
+
 	containerGroup := armcontainerinstance.ContainerGroup{
 		Location: to.Ptr(p.location),
 		Properties: &armcontainerinstance.ContainerGroupProperties{
 			Containers: []*armcontainerinstance.Container{
 				{
-					Name: to.Ptr(m.Application.Name),
-					Properties: &armcontainerinstance.ContainerProperties{
-						Image: to.Ptr(image),
-						Resources: &armcontainerinstance.ResourceRequirements{
-							Requests: &armcontainerinstance.ResourceRequests{
-								CPU:        to.Ptr(cpu),
-								MemoryInGB: to.Ptr(memoryGB),
-							},
-						},
-						Ports: []*armcontainerinstance.ContainerPort{
-							{
-								Port:     to.Ptr[int32](80),
-								Protocol: to.Ptr(armcontainerinstance.ContainerNetworkProtocolTCP),
-							},
-							{
-								Port:     to.Ptr[int32](443),
-								Protocol: to.Ptr(armcontainerinstance.ContainerNetworkProtocolTCP),
-							},
-						},
-						EnvironmentVariables: envVars,
-					},
+					Name:       to.Ptr(m.Application.Name),
+					Properties: containerProps,
 				},
 			},
 			OSType: to.Ptr(armcontainerinstance.OperatingSystemTypesLinux),

--- a/pkg/providers/azure/azure.go
+++ b/pkg/providers/azure/azure.go
@@ -582,8 +582,8 @@ func (p *Provider) deployContainerGroup(ctx context.Context, m *manifest.Manifes
 				Path: to.Ptr(m.HealthCheck.Path),
 				Port: to.Ptr[int32](80),
 			},
-			PeriodSeconds:      to.Ptr[int32](10),
-			FailureThreshold:   to.Ptr[int32](3),
+			PeriodSeconds:       to.Ptr[int32](10),
+			FailureThreshold:    to.Ptr[int32](3),
 			InitialDelaySeconds: to.Ptr[int32](5),
 		}
 		logging.Infof("Configured liveness probe with path: %s", m.HealthCheck.Path)

--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -478,6 +478,21 @@ func (p *Provider) deployService(ctx context.Context, m *manifest.Manifest, serv
 		container.Resources = resources
 	}
 
+	// Apply health check configuration as startup probe
+	if m.HealthCheck.Path != "" {
+		container.StartupProbe = &runpb.Probe{
+			ProbeType: &runpb.Probe_HttpGet{
+				HttpGet: &runpb.HTTPGetAction{
+					Path: m.HealthCheck.Path,
+				},
+			},
+			PeriodSeconds:    10,
+			FailureThreshold: 3,
+			TimeoutSeconds:   1,
+		}
+		logging.Infof("Configured startup probe with path: %s", m.HealthCheck.Path)
+	}
+
 	// Create revision template with deployment timestamp annotation to force new revision
 	revisionTemplate := &runpb.RevisionTemplate{
 		Containers: []*runpb.Container{container},


### PR DESCRIPTION
## Summary
- Fixes #36
- GCP: Configures a startup probe with HTTP health check path on Cloud Run containers
- Azure: Configures a liveness probe with HTTP health check path on ACI containers
- Both providers now honor `health_check.path` from the manifest, matching existing AWS behavior

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/providers/gcp/...` passes
- [x] `go test ./pkg/providers/azure/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)